### PR TITLE
fixed build

### DIFF
--- a/public/domain.te
+++ b/public/domain.te
@@ -483,7 +483,7 @@ neverallow { domain -init -recovery -vold } metadata_block_device:blk_file
   { append link rename write open read ioctl lock };
 
 # No domain other than recovery and update_engine can write to system partition(s).
-neverallow { domain -recovery -update_engine } system_block_device:blk_file write;
+neverallow { domain -recovery -update_engine userdebug_or_eng(`-init') } system_block_device:blk_file write;
 
 # No domains other than install_recovery or recovery can write to recovery.
 neverallow { domain -install_recovery -recovery } recovery_block_device:blk_file write;

--- a/public/domain.te
+++ b/public/domain.te
@@ -410,7 +410,7 @@ neverallow { domain -recovery -kernel -update_engine with_asan(`-asan_extract') 
 
 # Don't allow mounting on top of /system files or directories
 neverallow * exec_type:dir_file_class_set mounton;
-neverallow { domain -init } { system_file vendor_file_type }:dir_file_class_set mounton;
+neverallow { domain -init userdebug_or_eng(`-recovery') } { system_file vendor_file_type }:dir_file_class_set mounton;
 
 # Nothing should be writing to files in the rootfs.
 neverallow { domain userdebug_or_eng(`-recovery -update_engine') } rootfs:file { create write setattr relabelto append unlink link rename };


### PR DESCRIPTION
FAILED: /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy 
/bin/bash -c "(ASAN_OPTIONS=detect_leaks=0 /home/winkarbik/hdd/xenon/out/host/linux-x86/bin/checkpolicy -M -c 		30 -o /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy.tmp /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy.recovery.conf ) && (/home/winkarbik/hdd/xenon/out/host/linux-x86/bin/sepolicy-analyze /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy.tmp permissive > /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy.permissivedomains ) && (if [ \"userdebug\" = \"user\" -a -s /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy.permissivedomains ]; then 		echo \"==========\" 1>&2; 		echo \"ERROR: permissive domains not allowed in user builds\" 1>&2; 		echo \"List of invalid domains:\" 1>&2; 		cat /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy.permissivedomains 1>&2; 		exit 1; 		fi ) && (mv /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy.tmp /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy )"
libsepol.report_failure: neverallow on line 413 of system/sepolicy/public/domain.te (or line 8867 of policy.conf) violated by allow recovery system_file:dir { mounton };
libsepol.check_assertions: 1 neverallow failures occurred
Error while expanding policy
/home/winkarbik/hdd/xenon/out/host/linux-x86/bin/checkpolicy:  loading policy configuration from /home/winkarbik/hdd/xenon/out/target/product/cancro/obj/ETC/sepolicy.recovery_intermediates/sepolicy.recovery.conf
